### PR TITLE
fix: accept 201 on command creation

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -49,7 +49,7 @@ func (c *Client) AddCommand(app objects.Snowflake, command *objects.ApplicationC
 		return nil, err
 	}
 
-	if err = res.ExpectsStatus(http.StatusOK); err != nil {
+	if err = res.ExpectAnyStatus(http.StatusOK, http.StatusCreated); err != nil {
 		return nil, err
 	}
 

--- a/commands.go
+++ b/commands.go
@@ -49,7 +49,7 @@ func (c *Client) AddCommand(app objects.Snowflake, command *objects.ApplicationC
 		return nil, err
 	}
 
-	if err = res.ExpectAnyStatus(http.StatusOK, http.StatusCreated); err != nil {
+	if err = res.ExpectAnyStatus(http.StatusCreated); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
```
2021-08-19T23:48:34.018+0100    INFO    oscen/main.go:49        setting up discord client
2021-08-19T23:48:34.327+0100    INFO    oscen/main.go:60        connected to discord    {"username": "Oscen(dev)"}
2021-08-19T23:48:34.337+0100    INFO    router  interactions/interactions.go:50 registering command with router {"name": "np"}
2021-08-19T23:48:34.337+0100    INFO    router  interactions/interactions.go:50 registering command with router {"name": "register"}
2021/08/19 23:48:34 expected 200, got 201: {"id": "878047824493817856", "application_id": "876893270934945824", "name": "np", "description": "Shows your currently playing track", "version": "878047824493817857", "default_permission": false, "type": 1}
exit status 1
```